### PR TITLE
Make the diego healthcheck work on Windows

### DIFF
--- a/cmd/healthcheck/healthcheck_windows_test.go
+++ b/cmd/healthcheck/healthcheck_windows_test.go
@@ -1,9 +1,9 @@
-// +build !windows
-
 package main_test
 
 import (
+	"fmt"
 	"net"
+	"os"
 	"os/exec"
 	"strconv"
 
@@ -51,7 +51,12 @@ var _ = Describe("HealthCheck", func() {
 		var err error
 
 		portHealthCheck := func() *gexec.Session {
-			session, err := gexec.Start(exec.Command(healthCheck, "-port", port, "-timeout", "100ms"), GinkgoWriter, GinkgoWriter)
+			command := exec.Command(healthCheck, "-port", "8080", "-timeout", "100ms")
+			command.Env = append(
+				os.Environ(),
+				fmt.Sprintf(`CF_INSTANCE_PORTS=[{"external":%s,"internal":%s}]`, port, "8080"),
+			)
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 			return session
 		}
@@ -79,7 +84,12 @@ var _ = Describe("HealthCheck", func() {
 		var err error
 
 		httpHealthCheck := func() *gexec.Session {
-			session, err := gexec.Start(exec.Command(healthCheck, "-uri", "/api/_ping", "-port", port, "-timeout", "100ms"), GinkgoWriter, GinkgoWriter)
+			command := exec.Command(healthCheck, "-uri", "/api/_ping", "-port", "8080", "-timeout", "100ms")
+			command.Env = append(
+				os.Environ(),
+				fmt.Sprintf(`CF_INSTANCE_PORTS=[{"external":%s,"internal":%s}]`, port, "8080"),
+			)
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 			return session
 		}

--- a/cmd/healthcheck/main.go
+++ b/cmd/healthcheck/main.go
@@ -44,7 +44,7 @@ func main() {
 		return
 	}
 
-	h := healthcheck.NewHealthCheck(*network, *uri, *port, *timeout)
+	h := newHealthCheck(*network, *uri, *port, *timeout)
 	err = h.CheckInterfaces(interfaces)
 	if err == nil {
 		fmt.Println("healthcheck passed")

--- a/cmd/healthcheck/main_unix.go
+++ b/cmd/healthcheck/main_unix.go
@@ -1,0 +1,16 @@
+// +build !windows
+
+package main
+
+import (
+	"time"
+
+	"code.cloudfoundry.org/healthcheck"
+)
+
+func newHealthCheck(
+	network, uri, port string,
+	timeout time.Duration,
+) healthcheck.HealthCheck {
+	return healthcheck.NewHealthCheck(network, uri, port, timeout)
+}

--- a/cmd/healthcheck/main_windows.go
+++ b/cmd/healthcheck/main_windows.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"strconv"
+	"time"
+
+	"code.cloudfoundry.org/healthcheck"
+)
+
+type PortMapping struct {
+	Internal int `json:"internal"`
+	External int `json:"external"`
+}
+
+func newHealthCheck(
+	network, uri, port string,
+	timeout time.Duration,
+) healthcheck.HealthCheck {
+	jsonPortMappings := os.Getenv("CF_INSTANCE_PORTS")
+	var portMappings []PortMapping
+	json.Unmarshal([]byte(jsonPortMappings), &portMappings)
+	for _, mapping := range portMappings {
+		if strconv.Itoa(mapping.Internal) == port {
+			port = strconv.Itoa(mapping.External)
+		}
+	}
+	return healthcheck.NewHealthCheck(network, uri, port, timeout)
+}


### PR DESCRIPTION
Because Windows "containers" don't have network namespaces, we have to
map the internal port for health check to the external port that is
actually used by Windows applications.

This is in an effort to bring the windows_app_lifecycle in line with the
buildpackapplifecycle, and ultimately get rid of the WAL.

Signed-off-by: Natalie Arellano <narellano@pivotal.io>