### PR TITLE
Healthcheck can be used on windows 2012 and 2016

### DIFF
--- a/cmd/healthcheck/healthcheck_suite_test.go
+++ b/cmd/healthcheck/healthcheck_suite_test.go
@@ -16,8 +16,7 @@ func TestHealthCheck(t *testing.T) {
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {
-	healthCheckPath, err := gexec.Build("code.cloudfoundry.org/healthcheck/cmd/healthcheck")
-	Expect(err).NotTo(HaveOccurred())
+	healthCheckPath := buildHealthCheck()
 	return []byte(healthCheckPath)
 }, func(healthCheckPath []byte) {
 	healthCheck = string(healthCheckPath)

--- a/cmd/healthcheck/healthcheck_test.go
+++ b/cmd/healthcheck/healthcheck_test.go
@@ -1,11 +1,10 @@
-// +build !windows
-
 package main_test
 
 import (
 	"net"
 	"net/http"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"sync/atomic"
 	"syscall"
@@ -108,6 +107,9 @@ var _ = Describe("HealthCheck", func() {
 		})
 
 		It("exits with healthcheck error when signalled", func() {
+			if runtime.GOOS == "windows" {
+				Skip("SIGTERM does not work on windows")
+			}
 			session = httpHealthCheck()
 			Eventually(server.ReceivedRequests, 3*time.Second).Should(HaveLen(2))
 			session.Signal(syscall.SIGTERM)

--- a/cmd/healthcheck/helpers_internal_port_test.go
+++ b/cmd/healthcheck/helpers_internal_port_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !external
 
 package main_test
 
@@ -10,15 +10,21 @@ import (
 	"github.com/onsi/gomega/gexec"
 )
 
-func createPortHealthCheck(args []string, port string) *gexec.Session {
-	args = append([]string{"-port", port, "-timeout", "100ms"}, args...)
+func buildHealthCheck() string {
+	healthCheckPath, err := gexec.Build("code.cloudfoundry.org/healthcheck/cmd/healthcheck")
+	Expect(err).NotTo(HaveOccurred())
+	return healthCheckPath
+}
+
+func createHTTPHealthCheck(args []string, port string) *gexec.Session {
+	args = append([]string{"-uri", "/api/_ping", "-port", port, "-timeout", "100ms"}, args...)
 	session, err := gexec.Start(exec.Command(healthCheck, args...), GinkgoWriter, GinkgoWriter)
 	Expect(err).NotTo(HaveOccurred())
 	return session
 }
 
-func createHTTPHealthCheck(args []string, port string) *gexec.Session {
-	args = append([]string{"-uri", "/api/_ping", "-port", port, "-timeout", "100ms"}, args...)
+func createPortHealthCheck(args []string, port string) *gexec.Session {
+	args = append([]string{"-port", port, "-timeout", "100ms"}, args...)
 	session, err := gexec.Start(exec.Command(healthCheck, args...), GinkgoWriter, GinkgoWriter)
 	Expect(err).NotTo(HaveOccurred())
 	return session

--- a/cmd/healthcheck/main_external_port.go
+++ b/cmd/healthcheck/main_external_port.go
@@ -1,3 +1,5 @@
+// +build external
+
 package main
 
 import (

--- a/cmd/healthcheck/main_internal_port.go
+++ b/cmd/healthcheck/main_internal_port.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !external
 
 package main
 


### PR DESCRIPTION
Windows 2012 uses an external mapped port for the healthcheck, but windows 2016 (like linux) uses an internal port. This PR adds a flag (`useExternalPort`) which can be specified when compiling the healthcheck to use either the internal or external mapped port.

Building the healthcheck with the external port check will continue to be compatible with the declarative healthcheck on windows2012R2

Signed-off-by: Sunjay Bhatia <sbhatia@pivotal.io>