### PR TITLE
Add custom user-agent to HTTP health-checks

### DIFF
--- a/healthcheck.go
+++ b/healthcheck.go
@@ -83,6 +83,7 @@ func (h *HealthCheck) HTTPHealthCheck(ip string) error {
 		return HealthCheckError{Code: 6, Message: errMsg}
 	}
 
+	req.Header.Set("User-Agent", "diego-healthcheck")
 	req.Header.Set("X-Forwarded-Proto", "https")
 	resp, err := client.Do(req)
 	dur := time.Since(now)

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -244,6 +244,13 @@ var _ = Describe("HealthCheck", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(request.Header.Get("X-Forwarded-Proto")).To(Equal("https"))
 				})
+
+				It("should set the User-Agent header", func() {
+					err := hc.HTTPHealthCheck(ip)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(request.Header.Get("User-Agent")).To(Equal("diego-healthcheck"))
+				})
+
 			})
 
 		})


### PR DESCRIPTION
Closes https://github.com/cloudfoundry/diego-release/issues/455

***************************

## Please provide the following information:

### What is this change about?

Enabling automatic means of telling apart synthetic requests from the HTTP healthchecks from external requests.

### What problem it is trying to solve?

When performing distributed tracing in a Cloud Foundry app, there seems currently no generic way to tell apart a healthcheck call from another call, especially in the case the endpoint used for the check is also used by “productive” calls. Being able to ignore synthetic calls, which often follow streamlines code paths, is useful in providing an unbiased view of the status of the CF app in APM solutions.

### What is the impact if the change is not made?

There are no means of telling apart synthetic requests from the HTTP healthchecks from external requests, so APM tools cannot factor them out from the KPIs in terms of real-user usage.

### How should this change be described in diego-release release notes?

Diego HTTP healthchecks use now the value `diego-healthcheck` as `User-Agent`, which applications and APM tools can rely on to identify healthcheck requests.

### Please provide any contextual information.

https://github.com/cloudfoundry/diego-release/issues/455

### Tag your pair, your PM, and/or team!

That's fine thanks.

Thank you!
