### PR TITLE
Health check output

### DIFF
--- a/cmd/healthcheck/healthcheck_suite_test.go
+++ b/cmd/healthcheck/healthcheck_suite_test.go
@@ -12,7 +12,7 @@ var healthCheck string
 
 func TestHealthCheck(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "HealthCheck Suite")
+	RunSpecs(t, "HealthCheck CLI Suite")
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {

--- a/cmd/healthcheck/healthcheck_test.go
+++ b/cmd/healthcheck/healthcheck_test.go
@@ -204,7 +204,7 @@ var _ = Describe("HealthCheck", func() {
 				port = "-1"
 			})
 
-			itExitsWithCode(portHealthCheck, 4, "Failed to make TCP connection to port -1: connection refused")
+			itExitsWithCode(portHealthCheck, 4, "Failed to make TCP connection to port -1: dial tcp: address -1: invalid port")
 		})
 	})
 

--- a/cmd/healthcheck/healthcheck_test.go
+++ b/cmd/healthcheck/healthcheck_test.go
@@ -29,7 +29,7 @@ var _ = Describe("HealthCheck", func() {
 		It("exits with code "+strconv.Itoa(code)+" and logs reason", func() {
 			session := healthCheck()
 			Eventually(session).Should(gexec.Exit(code))
-			Expect(session.Out).To(gbytes.Say(reason))
+			Expect(session.Err).To(gbytes.Say(reason))
 		})
 	}
 
@@ -181,8 +181,8 @@ var _ = Describe("HealthCheck", func() {
 			Consistently(session).ShouldNot(gexec.Exit())
 			atomic.StoreInt64(&statusCode, http.StatusInternalServerError)
 			Eventually(session, 2*time.Second).Should(gexec.Exit(6))
-			Expect(session.Out).NotTo(gbytes.Say("healthcheck failed"))
-			Expect(session.Out).To(gbytes.Say("received status code 500 in"))
+			Expect(session.Err).NotTo(gbytes.Say("healthcheck failed"))
+			Expect(session.Err).To(gbytes.Say("received status code 500 in"))
 		})
 
 		It("runs a healthcheck every liveness-interval", func() {
@@ -204,7 +204,7 @@ var _ = Describe("HealthCheck", func() {
 				port = "-1"
 			})
 
-			itExitsWithCode(portHealthCheck, 4, "Failed to make TCP connection to port -1: dial tcp: address -1: invalid port")
+			itExitsWithCode(portHealthCheck, 4, "dial tcp: address -1: invalid port")
 		})
 	})
 

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -44,7 +44,6 @@ func (h *HealthCheck) CheckInterfaces(interfaces []net.Interface) error {
 
 		for _, a := range addrs {
 			if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() && ipnet.IP.To4() != nil {
-				fmt.Fprintf(os.Stdout, "Using %s for health checking (first non-loopback IPv4 addr found)\n", ipnet.IP.String())
 				err := healthcheck(ipnet.IP.String())
 				return err
 			}
@@ -63,11 +62,11 @@ func (h *HealthCheck) PortHealthCheck(ip string) error {
 	}
 
 	if err, ok := err.(net.Error); ok && err.Timeout() {
-		msg := fmt.Sprintf("Failed to make TCP connection to port %s: timed out after %.2f seconds", h.port, h.timeout.Seconds())
+		msg := fmt.Sprintf("failed to make TCP connection to %s: timed out after %.2f seconds", addr, h.timeout.Seconds())
 		return HealthCheckError{Code: 64, Message: msg}
 	}
 
-	return HealthCheckError{Code: 4, Message: fmt.Sprintf("Failed to make TCP connection to port %s: %s", h.port, err.Error())}
+	return HealthCheckError{Code: 4, Message: fmt.Sprintf("failed to make TCP connection to %s: %s", addr, err.Error())}
 }
 
 func (h *HealthCheck) HTTPHealthCheck(ip string) error {
@@ -79,7 +78,7 @@ func (h *HealthCheck) HTTPHealthCheck(ip string) error {
 	req, err := http.NewRequest("GET", addr, nil)
 	if err != nil {
 		errMsg := fmt.Sprintf(
-			"Failed to create an HTTP request to '%s' on port %s",
+			"failed to create an HTTP request to '%s' on port %s",
 			h.uri,
 			h.port,
 		)
@@ -103,7 +102,7 @@ func (h *HealthCheck) HTTPHealthCheck(ip string) error {
 		}
 
 		errMsg := fmt.Sprintf(
-			"Failed to make HTTP request to '%s' on port %s: received status code %d in %dms",
+			"failed to make HTTP request to '%s' on port %s: received status code %d in %dms",
 			h.uri,
 			h.port,
 			resp.StatusCode,
@@ -114,7 +113,7 @@ func (h *HealthCheck) HTTPHealthCheck(ip string) error {
 
 	if err, ok := err.(net.Error); ok && err.Timeout() {
 		errMsg := fmt.Sprintf(
-			"Failed to make HTTP request to '%s' on port %s: timed out after %.2f seconds",
+			"failed to make HTTP request to '%s' on port %s: timed out after %.2f seconds",
 			h.uri,
 			h.port,
 			h.timeout.Seconds(),
@@ -123,7 +122,7 @@ func (h *HealthCheck) HTTPHealthCheck(ip string) error {
 	}
 
 	errMsg := fmt.Sprintf(
-		"Failed to make HTTP request to '%s' on port %s: connection refused",
+		"failed to make HTTP request to '%s' on port %s: connection refused",
 		h.uri,
 		h.port,
 	)

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -64,7 +64,7 @@ func (h *HealthCheck) PortHealthCheck(ip string) error {
 		return HealthCheckError{Code: 64, Message: msg}
 	}
 
-	return HealthCheckError{Code: 4, Message: fmt.Sprintf("Failed to make TCP connection to port %s: connection refused", h.port)}
+	return HealthCheckError{Code: 4, Message: fmt.Sprintf("Failed to make TCP connection to port %s: %s", h.port, err.Error())}
 }
 
 func (h *HealthCheck) HTTPHealthCheck(ip string) error {

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -35,13 +35,17 @@ func (h *HealthCheck) CheckInterfaces(interfaces []net.Interface) error {
 	}
 
 	for _, intf := range interfaces {
+		fmt.Printf("Checking interface %v\n", intf)
 		addrs, err := intf.Addrs()
 		if err != nil {
+			fmt.Printf("Failed getting addresses for interface %v\n", intf)
 			continue
 		}
 
 		for _, a := range addrs {
+			fmt.Printf("Checking address %v\n", a)
 			if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() && ipnet.IP.To4() != nil {
+				fmt.Println("Found a non-loopback, IPV4 address")
 				err := healthcheck(ipnet.IP.String())
 				return err
 			}
@@ -55,6 +59,7 @@ func (h *HealthCheck) PortHealthCheck(ip string) error {
 	addr := ip + ":" + h.port
 	conn, err := net.DialTimeout(h.network, addr, h.timeout)
 	if err == nil {
+		fmt.Printf("Dialing the port %s succeeded\n", h.port)
 		conn.Close()
 		return nil
 	}

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -138,10 +138,7 @@ var _ = Describe("HealthCheck", func() {
 			})
 
 			It("returns healthcheck error with code 4 with an appropriate message", func() {
-				errMsg := fmt.Sprintf(
-					"Failed to make TCP connection to port %s: dial tcp: address -1: invalid port",
-					port,
-				)
+				errMsg := fmt.Sprintf("failed to make TCP connection to %s:%s: dial tcp: address %s: invalid port", ip, port, port)
 				itReturnsHealthCheckError(portHealthCheck, 4, errMsg)
 			})
 		})
@@ -156,11 +153,7 @@ var _ = Describe("HealthCheck", func() {
 			})
 
 			It("returns healthcheck error with code 64 with an appropriate message", func() {
-				errMsg := fmt.Sprintf(
-					"Failed to make TCP connection to port %s: timed out after %.2f seconds",
-					port,
-					timeout.Seconds(),
-				)
+				errMsg := fmt.Sprintf("failed to make TCP connection to %s:%s: timed out after 0.00 seconds", ip, port)
 				itReturnsHealthCheckError(portHealthCheck, 64, errMsg)
 			})
 		})
@@ -189,7 +182,7 @@ var _ = Describe("HealthCheck", func() {
 
 				It("returns healthcheck error with code 6 with an appropriate message", func() {
 					errMsg := fmt.Sprintf(
-						"Failed to make HTTP request to '%s' on port %s: received status code 500 in",
+						"failed to make HTTP request to '%s' on port %s: received status code 500 in",
 						uri,
 						port,
 					)
@@ -204,7 +197,7 @@ var _ = Describe("HealthCheck", func() {
 
 				It("returns healthcheck error with code 5 with an appropriate message", func() {
 					errMsg := fmt.Sprintf(
-						"Failed to make HTTP request to '%s' on port %s: connection refused",
+						"failed to make HTTP request to '%s' on port %s: connection refused",
 						uri,
 						port,
 					)
@@ -220,7 +213,7 @@ var _ = Describe("HealthCheck", func() {
 
 				It("returns healthcheck error with code 65 with an appropriate message", func() {
 					errMsg := fmt.Sprintf(
-						"Failed to make HTTP request to '%s' on port %s: timed out after %.2f seconds",
+						"failed to make HTTP request to '%s' on port %s: timed out after %.2f seconds",
 						uri,
 						port,
 						timeout.Seconds(),

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -139,7 +139,7 @@ var _ = Describe("HealthCheck", func() {
 
 			It("returns healthcheck error with code 4 with an appropriate message", func() {
 				errMsg := fmt.Sprintf(
-					"Failed to make TCP connection to port %s: connection refused",
+					"Failed to make TCP connection to port %s: dial tcp: address -1: invalid port",
 					port,
 				)
 				itReturnsHealthCheckError(portHealthCheck, 4, errMsg)


### PR DESCRIPTION
Resolves issues where failure messages encountered in healthcheck were being incorrectly ignored/reported. Clarifies messages and failure modes, as well as the timeouts and actions taken during readiness checks.