### PR TITLE
Support readiness health checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+cmd/healthcheck/healthcheck
 *.test
 *.coverprofile

--- a/cmd/healthcheck/healthcheck_test.go
+++ b/cmd/healthcheck/healthcheck_test.go
@@ -71,7 +71,7 @@ var _ = Describe("HealthCheck", func() {
 		return createHTTPHealthCheck(args, port)
 	}
 
-	Describe("in readiness mode", func() {
+	Describe("in startup mode", func() {
 		var (
 			session    *gexec.Session
 			statusCode int64
@@ -84,7 +84,7 @@ var _ = Describe("HealthCheck", func() {
 				resp.WriteHeader(int(statusCode))
 			}))
 
-			args = []string{"-readiness-interval=1s", "-readiness-timeout=2s"}
+			args = []string{"-startup-interval=1s", "-startup-timeout=2s"}
 		})
 
 		AfterEach(func() {
@@ -103,7 +103,7 @@ var _ = Describe("HealthCheck", func() {
 				if runtime.GOOS == "windows" {
 					Skip("skipping since SIGTERM probably doesn't work on Windows")
 				}
-				args = []string{"-readiness-interval=1s", "-readiness-timeout=60s"}
+				args = []string{"-startup-interval=1s", "-startup-timeout=60s"}
 			})
 
 			It("exits with healthcheck error when signalled", func() {
@@ -114,7 +114,7 @@ var _ = Describe("HealthCheck", func() {
 			})
 		})
 
-		It("runs a healthcheck every readiness-interval", func() {
+		It("runs a healthcheck every startup-interval", func() {
 			session = httpHealthCheck()
 			start := time.Now()
 			Eventually(server.ReceivedRequests, 3*time.Second).Should(HaveLen(2))
@@ -122,15 +122,15 @@ var _ = Describe("HealthCheck", func() {
 			Expect(end.Sub(start)).To(BeNumerically("~", 1*time.Second, 100*time.Millisecond))
 		})
 
-		It("exits with healthcheck error after readiness-timeout has been reached", func() {
+		It("exits with healthcheck error after startup-timeout has been reached", func() {
 			session = httpHealthCheck()
 			Eventually(server.ReceivedRequests).ShouldNot(BeEmpty())
 			Eventually(session, 3*time.Second).Should(gexec.Exit(6))
 		})
 
-		Context("when readiness timeout is set to 0", func() {
+		Context("when startup timeout is set to 0", func() {
 			BeforeEach(func() {
-				args = []string{"-readiness-interval=1s", "-readiness-timeout=0s"}
+				args = []string{"-startup-interval=1s", "-startup-timeout=0s"}
 			})
 
 			It("does not timeout", func() {
@@ -139,10 +139,10 @@ var _ = Describe("HealthCheck", func() {
 			})
 		})
 
-		Context("with low readiness interval", func() {
+		Context("with low startup interval", func() {
 			BeforeEach(func() {
 				server.HTTPTestServer.Close()
-				args = []string{"-readiness-interval=10ms"}
+				args = []string{"-startup-interval=10ms"}
 			})
 
 			It("continues to retry until the server is started", func() {

--- a/cmd/healthcheck/main.go
+++ b/cmd/healthcheck/main.go
@@ -34,16 +34,16 @@ var timeout = flag.Duration(
 	"dial timeout",
 )
 
-var readinessInterval = flag.Duration(
-	"readiness-interval",
+var startupInterval = flag.Duration(
+	"startup-interval",
 	0,
-	"if set, starts the healthcheck in readiness mode, i.e. do not exit until the healthcheck passes. runs checks every readiness-interval",
+	"if set, starts the healthcheck in startup mode, i.e. do not exit until the healthcheck passes. runs checks every startup-interval",
 )
 
-var readinessTimeout = flag.Duration(
-	"readiness-timeout",
+var startupTimeout = flag.Duration(
+	"startup-timeout",
 	60*time.Second,
-	"Only relevant if healthcheck is running in readiness mode. When the timeout is set to a non-zero value, the healthcheck will return non-zero with any errors if this timeout is hit without the healthcheck passing",
+	"Only relevant if healthcheck is running in startup mode. When the timeout is set to a non-zero value, the healthcheck will return non-zero with any errors if this timeout is hit without the healthcheck passing",
 )
 
 var livenessInterval = flag.Duration(
@@ -65,12 +65,12 @@ func main() {
 	h := newHealthCheck(*network, *uri, *port, *timeout)
 
 	var timeoutTimerCh <-chan time.Time
-	if duration := *readinessTimeout; duration > 0 {
+	if duration := *startupTimeout; duration > 0 {
 		timeoutTimerCh = time.NewTimer(duration).C
 	}
 
-	if readinessInterval != nil && *readinessInterval > 0 {
-		ticker := time.NewTicker(*readinessInterval)
+	if startupInterval != nil && *startupInterval > 0 {
+		ticker := time.NewTicker(*startupInterval)
 		defer ticker.Stop()
 		errCh := make(chan error)
 
@@ -86,14 +86,14 @@ func main() {
 					os.Exit(0)
 				}
 			case <-timeoutTimerCh:
-				fmt.Fprintf(os.Stderr, "Timed out after %s (%d attempts) waiting for readiness check to succeed: ", *readinessTimeout, attempt)
+				fmt.Fprintf(os.Stderr, "Timed out after %s (%d attempts) waiting for startup check to succeed: ", *startupTimeout, attempt)
 				failHealthCheck(err)
 			}
 
 			select {
 			case <-ticker.C:
 			case <-timeoutTimerCh:
-				fmt.Fprintf(os.Stderr, "Timed out after %s (%d attempts) waiting for readiness check to succeed: ", *readinessTimeout, attempt)
+				fmt.Fprintf(os.Stderr, "Timed out after %s (%d attempts) waiting for startup check to succeed: ", *startupTimeout, attempt)
 				failHealthCheck(err)
 			}
 		}

--- a/cmd/healthcheck/main.go
+++ b/cmd/healthcheck/main.go
@@ -58,6 +58,12 @@ var readinessInterval = flag.Duration(
 	"if set, starts the healthcheck in readiness mode, i.e. the app is ready to serve traffic, do not exit until the healthcheck fails because the target isn't serving traffic or another process doesn't exist. runs checks every readiness-interval",
 )
 
+var untilReadyInterval = flag.Duration(
+	"until-ready-interval",
+	0,
+	"if set, starts the healthcheck in until-ready mode, i.e. do not exit until the healthcheck passes and the app is ready to serve traffic. runs checks every until-ready-interval",
+)
+
 func main() {
 	flag.Parse()
 
@@ -124,6 +130,16 @@ func main() {
 				failHealthCheck(err)
 			}
 			time.Sleep(*readinessInterval)
+		}
+	}
+
+	if untilReadyInterval != nil && *untilReadyInterval > 0 {
+		for {
+			err = h.CheckInterfaces(interfaces)
+			if err == nil {
+				os.Exit(0)
+			}
+			time.Sleep(*untilReadyInterval)
 		}
 	}
 


### PR DESCRIPTION
### What is this change about?

Add support for readiness health checks. Rename old "readiness" health check to "startup". `readiness-interval` flag will instruct to run readiness  health check until it fails. `until-ready-interval` flag will instruct to run readiness  health check until it succeeds.

### How should this change be described in diego-release release notes?

Support readiness health checks

### Please provide any contextual information.

[RFC](https://github.com/cloudfoundry/community/pull/630)

Thank you!
